### PR TITLE
Add a Subscribe() function to the Consensus interface

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -14,6 +14,15 @@ type Consensus interface {
 	// SetActor sets the underlying actor that will actually be performing the
 	// operations of setting and changing the state.
 	SetActor(Actor)
+
+	// StateConsumer returns a channel that can be used to subscribe to
+	// state updates. Every new agreed-upon state of the system is sent to
+	// this channel.
+	Subscribe() <-chan State
+
+	// Unsubscribe stops sending updates and closes a previously opened
+	// Subscribe() channel. It does nothing if the channel does not exists.
+	Unsubscribe()
 }
 
 type Actor interface {


### PR DESCRIPTION
In order to build consensus systems it is necessary that every consensus member
can enjoy the possibility of subscribing to any updates in the state.
Otherwise they must GetCurrentState() repeteadly and innefficiently.

I have opted for a channel to do this because they seem appropiate for the use
case, although a similar behaviour would be achieved with something like
SetNewStateCallback(func(State)).

License: MIT
Signed-off-by: Hector Sanjuan <hector@protocol.ai>

@whyrusleeping @jbenet I would not mind some feedback here since you were the original creators of this interface.