### PR TITLE
Add [Un]RegisterOp() to OpLogConsensus

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -27,9 +27,16 @@ type Op interface {
 }
 
 type OpLogConsensus interface {
-	// CommitOp takes the current state and applies the given operation to it, then
-	// sets the new state as the clusters 'current' state.
-	CommitOp(Op) (State, error)
+	// Registers an operation, allowing to use it
+	RegisterOp(opName string, op Op)
+
+	// Unregisters an operation so it can no longer be commited
+	UnregisterOp(opName string, op Op)
+
+	// CommitOp submits an operation to the system. Once the operation
+	// is commited, it is applied to the current state of the system and
+	// the new state is returned.
+	CommitOp(opName string) (State, error)
 
 	SetActor(Actor)
 


### PR DESCRIPTION
OpLogConsensus provides a distributed log abstraction backed by an Actor
(consensus system). It sacrifices however the advantages of a distributed
log by assuming that the system agrees on the State and not on the log
that generates the state.

This is shown when it CommitOp() is expected to "setting the new state
 as the cluster given state". There's additional confusion: if the system
agrees on the final state, why is there an operation log at all? Does it need
to be kept alongside?

No. The advantage of a distributed log over a distributed state is that
the log (where every entry is small) can be used to reconstruct a potentially
huge final state. That means that the state cannot be transmitted. Instead,
only the operations (log) that make it should be agreed upon.

With that in mind, it is not possible to serialize and commit generic
operations to a distributed log, but we can assume that the members of such
cluster have pre-agreed on which operations they support, so we can
give them a name and use that name as the log entries.

RegisterOp() allows to assign a name to an operation. Those named-ops are
the distributed log, from which the State can be recreated, avoiding the
transmission of the full state on every update.

As a side note, the Consensus interface is just a particular simpler case of an
OpLogConsensus where the each Log entry == State. That is to say, the State
as a whole is trasmitted everywhere on every update.

@jbenet and @whyrusleeping , for this too, I would love your input